### PR TITLE
fix make install

### DIFF
--- a/bsd.prog.mk
+++ b/bsd.prog.mk
@@ -19,7 +19,8 @@ ${PROG}: ${OBJS} libopenbsd.a
 install: ${PROG} ${PAM_DOAS}
 	mkdir -p -m 0755 ${DESTDIR}${BINDIR}
 	mkdir -p -m 0755 ${DESTDIR}${PAMDIR}
-	mkdir -p -m 0755 ${DESTDIR}${MANDIR}/man{1,5}
+	mkdir -p -m 0755 ${DESTDIR}${MANDIR}/man1
+	mkdir -p -m 0755 ${DESTDIR}${MANDIR}/man5
 	cp -f ${PROG} ${DESTDIR}${BINDIR}
 	chown ${BINOWN}:${BINGRP} ${DESTDIR}${BINDIR}/${PROG}
 	chmod ${BINMODE} ${DESTDIR}${BINDIR}/${PROG}

--- a/configure
+++ b/configure
@@ -7,7 +7,7 @@ die() {
 
 usage() {
 	cat <<EOF
-usage: configure [options] [settings]
+usage: configure [options]
 
   --prefix=PREFIX        installation prefix [/usr]
   --exec-prefix=EPREFIX  installation prefix for executable files [PREFIX]
@@ -58,7 +58,7 @@ rm -f "$CONFIG_MK"
 : ${VERSION:="$(git describe --dirty --tags --long --always)"}
 
 cat <<EOF >>$CONFIG_MK
-DESTDIR  ?=	/
+DESTDIR  ?=
 PREFIX   ?=	${PREFIX:="/usr"}
 EPREFIX  ?=	${EPREFIX:="${PREFIX}"}
 BINDIR   ?=	${BINDIR:="${PREFIX}/bin"}


### PR DESCRIPTION
  man{1,5} is not expanded

set default DESTDIR to an empty string
  `mkdir -p //usr/bin` - it creates dir, but looks not very nice

also remove "[settings]" from configure usage