### PR TITLE
Print -a flag in usage() only if HAVE_BSD_AUTH_H

### DIFF
--- a/doas.c
+++ b/doas.c
@@ -46,8 +46,14 @@ version(void)
 static void __dead
 usage(void)
 {
+#ifdef HAVE_BSD_AUTH_H
 	fprintf(stderr, "usage: doas [-nsv] [-a style] [-C config] [-u user]"
 	    " command [args]\n");
+#else
+	fprintf(stderr, "usage: doas [-nsv] [-C config] [-u user]"
+	    " command [args]\n");
+#endif
+	    
 	exit(1);
 }
 


### PR DESCRIPTION
Just realized that `-a` was printed in usage, but I couldn't actually use it.

And unrelated note/question: Are there plans on porting the new `persist` keyword? 