### PR TITLE
doas.c: put login_style in ifdef to compile on Linux

### DIFF
--- a/doas.c
+++ b/doas.c
@@ -340,7 +340,9 @@ main(int argc, char **argv)
 	char cwdpath[PATH_MAX];
 	const char *cwd;
 	char **envp;
+#ifdef HAVE_BSD_AUTH_H
 	char *login_style = NULL;
+#endif
 
 	setprogname("doas");
 


### PR DESCRIPTION
This fixes the build on Linux. I don't have a bsd to test it against, but it's identical to the ifdefs used elsewhere for this same variable. If I've missed something, I'm happy to revise.

This would close #22.