### PR TITLE
Change binary permissions to 4755. Closes #26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MAN=	doas.1 doas.conf.5
 
 BINOWN= root
 BINGRP= root
-BINMODE=4111
+BINMODE=4755
 
 CFLAGS+= -I${CURDIR}
 COPTS+=	-Wall -Wextra -Werror -pedantic


### PR DESCRIPTION
The owner can be trusted to read and write their own files, and
there's no reason not to let others read the file.