### PR TITLE
Honor --sysconfdir option for doas.conf path.

### DIFF
--- a/bsd.prog.mk
+++ b/bsd.prog.mk
@@ -6,6 +6,8 @@ CFLAGS  += -I${CURDIR}/libopenbsd ${COPTS} -MD -MP -Wno-unused-result
 
 include config.mk
 
+CFLAGS	+= -DDOAS_CONF="\"${SYSCONFDIR}/doas.conf\""
+
 OPENBSD := $(addprefix libopenbsd/,${OPENBSD})
 OBJS    := ${SRCS:.y=.c}
 OBJS    := ${OBJS:.c=.o}

--- a/doas.c
+++ b/doas.c
@@ -325,7 +325,7 @@ main(int argc, char **argv)
 	if (geteuid())
 		errx(1, "not installed setuid");
 
-	parseconfig("/etc/doas.conf", 1);
+	parseconfig(DOAS_CONF, 1);
 
 	/* cmdline is used only for logging, no need to abort on truncate */
 	(void)strlcpy(cmdline, argv[0], sizeof(cmdline));


### PR DESCRIPTION
Some distributions may choose to place configuration files in a different
directory than /etc. The configure script provides --sysconfdir
option already, use it to find doas.conf path instead of hardcoding
'/etc/doas.conf'.