### PR TITLE
Provide a fallback for setresuid(2).

### DIFF
--- a/configure
+++ b/configure
@@ -340,7 +340,7 @@ int main(void) {
 	setresuid(0, 0, 0);
 	return 0;
 }'
-check_func "setresuid" "$src" || die "system has no setresuid(2): not supported"
+check_func "setresuid" "$src"
 
 #
 # Check for closefrom().

--- a/doas.c
+++ b/doas.c
@@ -34,6 +34,11 @@
 #include "includes.h"
 #include "doas.h"
 
+#ifndef HAVE_SETRESUID
+#define setresgid(a, b, c)     setgid(a)
+#define setresuid(a, b, c)     setuid(a)
+#endif
+
 static void __dead
 usage(void)
 {


### PR DESCRIPTION
On platforms(NetBSD, MacOS) missing setresuid(2), fallback to
setuid(2)/setgid(2).