### PR TITLE
Fallback definition for HOST_NAME_MAX.

### DIFF
--- a/pam.c
+++ b/pam.c
@@ -271,6 +271,9 @@ pamauth(const char *user, const char *myname, int interactive, int nopass, int p
 		if (!interactive)
 			errx(1, "Authorization required");
 
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
 		/* doas style prompt for pam */
 		char host[HOST_NAME_MAX + 1];
 		if (gethostname(host, sizeof(host)))


### PR DESCRIPTION
On some platforms(NetBSD) where HOST_NAME_MAX is not defined,
provide a fallback definition to _POSIX_HOST_NAME_MAX.