### PR TITLE
opendoas: Fallback for setresuid(2).

### DIFF
--- a/configure
+++ b/configure
@@ -340,7 +340,9 @@ int main(void) {
 	setresuid(0, 0, 0);
 	return 0;
 }'
-check_func "setresuid" "$src" || die "system has no setresuid(2): not supported"
+check_func "setresuid" "$src" || {
+	printf 'OPENBSD  +=	bsd-setres_id.o\n' >>$CONFIG_MK
+}
 
 #
 # Check for closefrom().

--- a/libopenbsd/bsd-setres_id.c
+++ b/libopenbsd/bsd-setres_id.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2012 Darren Tucker (dtucker at zip com au).
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "includes.h"
+
+#include <sys/types.h>
+
+#include <errno.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <string.h>
+
+#if !defined(HAVE_SETRESGID) || defined(BROKEN_SETRESGID)
+int
+setresgid(gid_t rgid, gid_t egid, gid_t sgid)
+{
+	int ret = 0;
+
+	if (rgid != sgid) {
+		errno = ENOSYS;
+		return -1;
+	}
+#if defined(HAVE_SETREGID) && !defined(BROKEN_SETREGID)
+	if (setregid(rgid, egid) < 0) {
+		ret = -1;
+	}
+#else
+	if (setegid(egid) < 0) {
+		ret = -1;
+	}
+	if (setgid(rgid) < 0) {
+		ret = -1;
+	}
+#endif
+	return ret;
+}
+#endif
+
+#if !defined(HAVE_SETRESUID) || defined(BROKEN_SETRESUID)
+int
+setresuid(uid_t ruid, uid_t euid, uid_t suid)
+{
+	int ret = 0;
+
+	if (ruid != suid) {
+		errno = ENOSYS;
+		return -1;
+	}
+#if defined(HAVE_SETREUID) && !defined(BROKEN_SETREUID)
+	if (setreuid(ruid, euid) < 0) {
+		ret = -1;
+	}
+#else
+
+# ifndef SETEUID_BREAKS_SETUID
+	if (seteuid(euid) < 0) {
+		ret = -1;
+	}
+# endif
+	if (setuid(ruid) < 0) {
+		ret = -1;
+	}
+#endif
+	return ret;
+}
+#endif

--- a/libopenbsd/openbsd.h
+++ b/libopenbsd/openbsd.h
@@ -64,4 +64,11 @@ const char * getprogname(void);
 void setprogname(const char *progname);
 #endif /* !HAVE_SETPROGNAME */
 
+#ifndef HAVE_SETRESGID
+int	setresgid(gid_t, gid_t, gid_t);
+#endif
+#ifndef HAVE_SETRESUID
+int	setresuid(uid_t, uid_t, uid_t);
+#endif
+
 #endif /* _LIB_OPENBSD_H_ */


### PR DESCRIPTION
This approach borrows from openssh-portable. The bsd-setres_id.c
is adapted with openssh-portable specific bits (log.h inclusion
and error() function) removed.