### PR TITLE
Add `DEFAULT_PATH` to match de-facto Linux standards

### DIFF
--- a/configure
+++ b/configure
@@ -30,6 +30,8 @@ usage: configure [options]
 
   --uid-max=NUM          set UID_MAX (default 65535)
   --gid-max=NUM          set GID_MAX (default 65535)
+  
+  --default-path=PATH    set default PATH for executed environment
 
   --help, -h             display this help and exit
 EOF
@@ -40,6 +42,7 @@ EOF
 WITHOUT_TIMESTAMP=yes
 UID_MAX=65535
 GID_MAX=65535
+DEFAULT_PATH="/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin"
 
 for x; do
 	opt=${x%%=*}
@@ -64,6 +67,7 @@ for x; do
 	--without-timestamp) WITHOUT_TIMESTAMP=yes ;;
 	--uid-max) UID_MAX=$var ;;
 	--gid-max) UID_MAX=$var ;;
+	--default-path) DEFAULT_PATH=$var ;;
 	--help|-h) usage ;;
 	*) die "Error: unknown option $opt" ;;
 	esac
@@ -103,6 +107,9 @@ if [ -z "$OS" ]; then
 fi
 
 OS_CFLAGS="-D__${OS}__"
+
+printf 'Setting DEFAULT_PATH\t\t\t%s.\n' "$DEFAULT_PATH" >&2
+printf '#define DEFAULT_PATH "%s"\n' "$DEFAULT_PATH" >>$CONFIG_H
 
 case "$OS" in
 	linux)

--- a/doas.c
+++ b/doas.c
@@ -397,8 +397,8 @@ main(int argc, char **argv)
 		err(1, "initgroups");
 	if (setresuid(target, target, target) != 0)
 		err(1, "setresuid");
-	if (setenv("PATH", safepath, 1) == -1)
-		err(1, "failed to set PATH '%s'", safepath);
+	if (setenv("PATH", DEFAULT_PATH, 1) == -1)
+		err(1, "failed to set PATH '%s'", DEFAULT_PATH);
 #endif
 
 	if (getcwd(cwdpath, sizeof(cwdpath)) == NULL)


### PR DESCRIPTION
`DEFAULT_PATH` replaces `safepath` for setting the `PATH` variable in the executed process's environment.

`DEFAULT_PATH` follows the de-facto standard of Linux distributions which place `/usr/local` directories before their non-local counterparts in $PATH.

Unlike BSD, Linux distributions don't put packaged executables under `/usr/local`, instead it is used by the local user to place their own executables, potentially to replace system executables.

This fixes #117