### PR TITLE
Retry up to 3 times on password authentication failure

### DIFF
--- a/doas.h
+++ b/doas.h
@@ -44,6 +44,8 @@ char **prepenv(const struct rule *, const struct passwd *,
 #define PERSIST		0x4
 #define NOLOG		0x8
 
+#define AUTH_RETRIES	3
+
 #ifdef USE_PAM
 void pamauth(const char *, const char *, int, int, int);
 #endif

--- a/shadow.c
+++ b/shadow.c
@@ -80,23 +80,28 @@ shadowauth(const char *myname, int persist)
 	snprintf(cbuf, sizeof(cbuf),
 			"\rdoas (%.32s@%.32s) password: ", myname, host);
 	challenge = cbuf;
-
-	response = readpassphrase(challenge, rbuf, sizeof(rbuf), RPP_REQUIRE_TTY);
-	if (response == NULL && errno == ENOTTY) {
-		syslog(LOG_AUTHPRIV | LOG_NOTICE,
-			"tty required for %s", myname);
-		errx(1, "a tty is required");
-	}
-	if (response == NULL)
-		err(1, "readpassphrase");
-	if ((encrypted = crypt(response, hash)) == NULL) {
-		explicit_bzero(rbuf, sizeof(rbuf));
-		errx(1, "Authentication failed");
-	}
-	explicit_bzero(rbuf, sizeof(rbuf));
-	if (strcmp(encrypted, hash) != 0) {
-		syslog(LOG_AUTHPRIV | LOG_NOTICE, "failed auth for %s", myname);
-		errx(1, "Authentication failed");
+	for (int i = 0; i < AUTH_RETRIES; i++) {
+		response = readpassphrase(challenge, rbuf, sizeof(rbuf), RPP_REQUIRE_TTY);
+		if (response == NULL && errno == ENOTTY) {
+			syslog(LOG_AUTHPRIV | LOG_NOTICE,
+				"tty required for %s", myname);
+			errx(1, "a tty is required");
+		}
+		if (response == NULL)
+			err(1, "readpassphrase");
+		if ((encrypted = crypt(response, hash)) == NULL) {
+			explicit_bzero(rbuf, sizeof(rbuf));
+			(i == AUTH_RETRIES - 1) ? errx(1, "Authentication failed") : warnx("Authentication failed");
+		}
+		else {
+			explicit_bzero(rbuf, sizeof(rbuf));
+			if (strcmp(encrypted, hash) != 0) {
+				syslog(LOG_AUTHPRIV | LOG_NOTICE, "failed auth for %s", myname);
+				(i == AUTH_RETRIES - 1) ? errx(1, "Authentication failed") : warnx("Authentication failed");
+			}
+			else
+				break;
+		}
 	}
 
 #ifdef USE_TIMESTAMP


### PR DESCRIPTION
Resolves https://github.com/Duncaen/OpenDoas/issues/82

https://github.com/Duncaen/OpenDoas/pull/102 was closed a few days ago, so I decided to take my shot. Took a look at the comments you left, and based my changes on that.

For the pam loop, I took a look and retrying authentication with a loop seems like an expected thing to do. From https://www.ibm.com/docs/en/aix/7.2?topic=p-pam-authenticate-subroutine:
> On failure, it is the responsibility of the calling application to maintain a count of authentication attempts and to reinvoke the subroutine if the count has not exceeded a defined limit.