### PR TITLE
Backport patch for increased rowhammer resistance from OpenBSD

### DIFF
--- a/doas.h
+++ b/doas.h
@@ -36,7 +36,7 @@ struct passwd;
 char **prepenv(const struct rule *, const struct passwd *,
     const struct passwd *);
 
-#define PERMIT	1
+#define PERMIT	-1
 #define DENY	2
 
 #define NOPASS		0x1


### PR DESCRIPTION
This commit backports an OpenBSD doas change which attempt to make doas more resistant to rowhammer attacks.

A similar change has been committed to sudo last year.

See:

* https://github.com/openbsd/src/commit/38599afa1d1d1f14a897b01350e8ce94486e1788
* https://github.com/sudo-project/sudo/commit/7873f8334c8d31031f8cfa83bd97ac6029309e4f
* https://doi.org/10.48550/arXiv.2309.02545