### PR TITLE
Added freebsd support for timestamp (persist)

### DIFF
--- a/configure
+++ b/configure
@@ -224,6 +224,9 @@ int main(void) {
 persistmethod() {
 	[ -z "$WITHOUT_TIMESTAMP" ] && {
 		printf '#define USE_TIMESTAMP\n' >>$CONFIG_H
+		printf '#ifdef __freebsd__\n' >>$CONFIG_H
+		printf '# define TIMESTAMP_DIR "/var/run/doas"\n' >>$CONFIG_H
+		printf '#endif\n' >>$CONFIG_H
 		printf 'SRCS	+= timestamp.c\n' >>$CONFIG_MK
 		printf 'timestamp\n'
 		return 0


### PR DESCRIPTION
This fixes #109. Not too many changes needed, I can build this successfully and verify persist is working with the following build commands:

```sh
# ./configure --without-shadow --with-timestamp --sysconfdir=/usr/local/etc
# gmake
# gmake install
```